### PR TITLE
Added struct and class object expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,9 @@ With everything set up, start `python dap_server.py` and then start a debugging 
 ## Issues
 As this is an early state, there are lots of issues. Some of them are listed here - so you have been warned.
 
-* Slow startup times - When launching a debug session (in neovim anyway), it takes some time until your first breakpoint is hit, even if that breakpoint is the first line in your main function
 * Errors not caught correctly - In my program I'm trying this out on, there is a line of code that I haven't been able to get past; still neovim never showed me that the debugger stopped executing. The program didn't crash.
 * StopOnEntry - Not supported yet. cdb has a stop on entry functionality, but if you have debugged in lldb or gdb before, you expect this to stop at the beginning of the main function. cdb stops elsewhere, so for now this is "disabled".
 * When debugging the test_program.cpp in this repository, multiple threads are started (by Cdb).
 This is annoying during debugging, but the "unimportant" threads don't have user code associated, so this should not be a big issue.
 * There is support for C style arrays and std::vectors, but not for other containers (yet).
-* Now work has been done on object members yet.
+* There is limited support for objects of structs and classes. E.g. in the test_program.cpp You can look into Rectangle, Point and Node - however in the case of Node, the next member will show only an address (that can be expanded though).

--- a/test_program/test_program.cpp
+++ b/test_program/test_program.cpp
@@ -1,6 +1,38 @@
 #include <iostream>
+#include <queue>
 #include <vector>
 #include <string>
+#include <cmath>
+
+// Simple struct for testing member inspection
+struct Point {
+    int x;
+    int y;
+    double distance() const {
+        return sqrt(x * x + y * y);
+    }
+};
+
+struct Node {
+    Node(int val) : val(val) {}
+    Node(Node* next, int val) : next(next), val(val) {}
+    Node* next = nullptr;
+    int val = 0;
+};
+
+// Simple class for testing member inspection
+class Rectangle {
+public:
+    int width;
+    int height;
+    Point topLeft;
+    
+    Rectangle(int w, int h, Point tl) : width(w), height(h), topLeft(tl) {}
+    
+    int area() const {
+        return width * height;
+    }
+};
 
 int fibonacci(int n) {
     bool printN = false;
@@ -16,10 +48,23 @@ int fibonacci(int n) {
 int main(int argc, char** argv) {
     std::cout << "C++ Debug Test Program" << std::endl;
     
+    // Test struct and class objects
+    Point p1 = {10, 20};
+    Point p2 = {-5, 15};
+    Rectangle rect(100, 50, p1);
+
+    Node n1(1);
+    Node n2(&n1, 2);
+    Node n3(&n2, 3);
+    
     // Test variables of different types
     int number = 42;
     double pi = 3.14159;
     std::string message = "Hello, Debugger!";
+    std::queue<std::string> stringQueue;
+    stringQueue.push("first");
+    stringQueue.push("second");
+    stringQueue.push("third");
     std::vector<int> numbers = {1, 2, 3, 4, 5};
     int* numbersPtr = new int[5];
     int numbersArr[] = {2, 4, 8, 16, 32};


### PR DESCRIPTION
- structs and classes can now be expanded in the DAP client
- member information is stripped in the expansion (I will probably undo that)
- Pointer members are shown as addresses and it is not clear they can be expanded - but they can! E.g. test_program.cpp Node struct.